### PR TITLE
Fix proxy class bug

### DIFF
--- a/src/Glorp-Integration-Tests/GlorpProxyTest.class.st
+++ b/src/Glorp-Integration-Tests/GlorpProxyTest.class.st
@@ -85,3 +85,14 @@ GlorpProxyTest >> testSpecies [
 
 	self assert: proxy species equals: GlorpAddress 
 ]
+
+{ #category : #tests }
+GlorpProxyTest >> testSpeciesisProxy [
+"a proxy without a result or a query returns Proxy as species"
+
+	| prox |
+	
+	prox := Proxy new.
+
+	self assert: prox species equals: Proxy 
+]

--- a/src/Glorp-Integration-Tests/GlorpProxyTest.class.st
+++ b/src/Glorp-Integration-Tests/GlorpProxyTest.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #GlorpTestCase,
 	#instVars : [
 		'session',
-		'proxy'
+		'proxy',
+		'result'
 	],
 	#category : #'Glorp-Integration-Tests-Database'
 }
@@ -23,7 +24,8 @@ GlorpProxyTest >> setUp [
 	proxy := Proxy new.
 	proxy session: session.
 	stub := GlorpQueryStub readOneOf: GlorpAddress where: [:address | address id = 1].
-	stub result: 42.
+	result:= GlorpAddress new.
+	stub result: result.
 	proxy query: stub.
 	proxy parameters: #()
 ]
@@ -55,7 +57,7 @@ GlorpProxyTest >> testCreation [
 GlorpProxyTest >> testInstantiationFromStub [
 
 	self assert: (proxy getValue notNil).
-	self assert: proxy = 42.
+	self assert: proxy equals: result.
 	self assert: proxy isInstantiated.
 ]
 
@@ -76,4 +78,10 @@ GlorpProxyTest >> testPrintingUninstantiated [
 GlorpProxyTest >> testPrintingUninstantiatedCollection [
 	proxy query readsOneObject: false.
 	self assert: proxy printString = '{uninstantiated collection of GlorpAddress}'.
+]
+
+{ #category : #tests }
+GlorpProxyTest >> testSpecies [ 
+
+	self assert: proxy species equals: GlorpAddress 
 ]

--- a/src/Glorp/Proxy.class.st
+++ b/src/Glorp/Proxy.class.st
@@ -208,10 +208,13 @@ Proxy >> session: aSession [
 
 { #category : #accessing }
 Proxy >> species [
+"returns the class of the proxied object either by looking at the actual value's class"
+"or the expected result of the proxy. Returns Proxy otherwise."
 
 	self isInstantiated ifTrue: [^value species].
 	query isNil ifTrue: [^Proxy].
-	query resultClass isNil ifTrue: [^Proxy].
-	^query resultClass 
+	"self traceCr: 'not instantiated'."
+	^ query resultClass ifNil: [ Proxy ]
+	
 
 ]

--- a/src/Glorp/Proxy.class.st
+++ b/src/Glorp/Proxy.class.st
@@ -212,6 +212,6 @@ Proxy >> species [
 	self isInstantiated ifTrue: [^value species].
 	query isNil ifTrue: [^Proxy].
 	query resultClass isNil ifTrue: [^Proxy].
-	^query resultClass species
+	^query resultClass 
 
 ]


### PR DESCRIPTION
Proxy>>species returned the metaclass of the result of the query, instead of the class.